### PR TITLE
fix guzzle error

### DIFF
--- a/src/ServiceContainer/Driver/MailTrapFactory.php
+++ b/src/ServiceContainer/Driver/MailTrapFactory.php
@@ -19,10 +19,10 @@ class MailTrapFactory
     {
         if (isset($config['api_key']) && isset($config['mailbox_id'])) {
             $client = new Client([
-                'base_url' => 'https://mailtrap.io',
-                'defaults' => [
-                    'headers' => ['Api-Token' => $config['api_key']]
-                ]
+                'base_uri' => 'https://mailtrap.io',
+                'headers' => [
+                    'Api-Token' => $config['api_key'],
+                ],
             ]);
 
             return new MailTrap($client, $config['mailbox_id']);


### PR DESCRIPTION
After migration to Guzzle 6 there was an error

cURL error 3: <url> malformed (see http://curl.haxx.se/libcurl/c/libcurl-errors.html) (GuzzleHttp\Exception\RequestException)
